### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ And in `application.js`:
 Usage
 -----
 
-###Remote pages
+### Remote pages
 Usual remote link:
 
 ```haml
@@ -112,7 +112,7 @@ $.lazybox.close()
 window.location.reload()
 ```
 
-###Confirmations
+### Confirmations
 
 You can replace standard rails confirmations with lazybox
 
@@ -134,7 +134,7 @@ or instance settings
 $.lazybox("<div>It works!</div>",{modal: true, close: false})
 ```
 
-###Images
+### Images
 
 ```haml
 - link_to 'Image', image.url, rel: :lazybox


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
